### PR TITLE
PR 16: Create Directives for Register Form

### DIFF
--- a/Angular/viver-cellers/src/app/app.module.ts
+++ b/Angular/viver-cellers/src/app/app.module.ts
@@ -14,6 +14,8 @@ import { PectComponent } from './components/pect/pect.component';
 import { RegisterComponent } from './components/register/register.component';
 import { LoginComponent } from './components/login/login.component';
 import { ReactiveFormsModule } from '@angular/forms';
+import { DniDirective } from './directives/dni.directive';
+import { RepeatPasswordDirective } from './directives/repeat-password.directive';
 
 @NgModule({
   declarations: [
@@ -28,6 +30,8 @@ import { ReactiveFormsModule } from '@angular/forms';
     PectComponent,
     RegisterComponent,
     LoginComponent,
+    DniDirective,
+    RepeatPasswordDirective,
   ],
   imports: [
     BrowserModule,

--- a/Angular/viver-cellers/src/app/components/login/login.component.html
+++ b/Angular/viver-cellers/src/app/components/login/login.component.html
@@ -70,6 +70,16 @@
                       Inicieu sessió
                     </button>
                   </div>
+
+                  <!-- Register button -->
+                  <div class="flex items-center justify-between pb-6">
+                    <p class="mb-0 me-2">No tens un compte?</p>
+                    <button type="button"
+                      class="rounded border-2 border-danger px-6 pb-[6px] pt-2 text-xs font-medium uppercase leading-normal text-danger transition duration-150 ease-in-out hover:border-danger-600 hover:bg-danger-50/50 hover:text-danger-600 focus:border-danger-600 focus:bg-danger-50/50 focus:text-danger-600 focus:outline-none focus:ring-0 active:border-danger-700 active:text-danger-700 dark:hover:bg-rose-950 dark:focus:bg-rose-950"
+                      data-twe-ripple-init data-twe-ripple-color="light" routerLink="/register">
+                      Register
+                    </button>
+                  </div>
                 </form>
               </div>
             </div>

--- a/Angular/viver-cellers/src/app/components/register/register.component.html
+++ b/Angular/viver-cellers/src/app/components/register/register.component.html
@@ -108,7 +108,7 @@
                   <div class="form-group relative mb-4" data-twe-input-wrapper-init>
                     <input type="text"
                       class="peer block min-h-[auto] w-full rounded border-0 bg-transparent px-3 py-[0.32rem] leading-[1.6] outline-none transition-all duration-200 ease-linear focus:placeholder:opacity-100 peer-focus:text-primary data-[twe-input-state-active]:placeholder:opacity-100 motion-reduce:transition-none dark:text-white dark:placeholder:text-neutral-300 dark:autofill:shadow-autofill dark:peer-focus:text-primary [&:not([data-twe-input-placeholder-active])]:placeholder:opacity-0"
-                      placeholder="DNI" formControlName="dni" />
+                      placeholder="DNI" formControlName="dni" appDni=dni />
                     <label for="dni"
                       class="pointer-events-none absolute left-3 top-0 mb-0 max-w-[90%] origin-[0_0] truncate pt-[0.37rem] leading-[1.6] text-neutral-500 transition-all duration-200 ease-out peer-focus:-translate-y-[0.9rem] peer-focus:scale-[0.8] peer-focus:text-primary peer-data-[twe-input-state-active]:-translate-y-[0.9rem] peer-data-[twe-input-state-active]:scale-[0.8] motion-reduce:transition-none dark:text-neutral-400 dark:peer-focus:text-primary">DNI
                     </label>
@@ -129,6 +129,12 @@
                     <div *ngIf="this.register.get('dni')?.errors?.['minlength'] &&
                      this.register.get('dni')?.touched" class="text-red-500 text-xs italic">
                       Aquest camp només pot contenir com a mínim 9 caràcters.
+                    </div>
+
+                    <!-- Custom -->
+                    <div *ngIf="this.register.get('dni')?.errors?.['custom'] &&
+                    this.register.get('dni')?.touched" class="text-red-500 text-xs italic">
+                      DNI incorrecte
                     </div>
                   </div>
 
@@ -181,7 +187,7 @@
                   <div class="form-group relative mb-4" data-twe-input-wrapper-init>
                     <input type="password"
                       class="peer block min-h-[auto] w-full rounded border-0 bg-transparent px-3 py-[0.32rem] leading-[1.6] outline-none transition-all duration-200 ease-linear focus:placeholder:opacity-100 peer-focus:text-primary data-[twe-input-state-active]:placeholder:opacity-100 motion-reduce:transition-none dark:text-white dark:placeholder:text-neutral-300 dark:autofill:shadow-autofill dark:peer-focus:text-primary [&:not([data-twe-input-placeholder-active])]:placeholder:opacity-0"
-                      placeholder="Password" formControlName="repeatpassword" />
+                      placeholder="Password" formControlName="repeatpassword" appRepeatPassword=password />
                     <label for="repeatpassword"
                       class="pointer-events-none absolute left-3 top-0 mb-0 max-w-[90%] origin-[0_0] truncate pt-[0.37rem] leading-[1.6] text-neutral-500 transition-all duration-200 ease-out peer-focus:-translate-y-[0.9rem] peer-focus:scale-[0.8] peer-focus:text-primary peer-data-[twe-input-state-active]:-translate-y-[0.9rem] peer-data-[twe-input-state-active]:scale-[0.8] motion-reduce:transition-none dark:text-neutral-400 dark:peer-focus:text-primary">Repetir
                       Contrasenya
@@ -191,6 +197,12 @@
                     <div *ngIf="this.register.get('repeatpassword')?.errors?.['required'] &&
                     this.register.get('repeatpassword')?.touched" class="text-red-500 text-xs italic">
                       Aquest camp és obligatori.
+                    </div>
+
+                    <!-- Match password -->
+                    <div *ngIf="this.register.get('repeatpassword')?.errors?.['custom'] &&
+                    this.register.get('repeatpassword')?.touched" class="text-red-500 text-xs italic">
+                      Les contrasenyes han de coincidir.
                     </div>
                   </div>
 
@@ -256,7 +268,7 @@
                     </button>
                   </div>
 
-                  <!-- Register button -->
+                  <!-- Login button -->
                   <div class="flex items-center justify-between pb-6">
                     <p class="mb-0 me-2">Ja tens un compte?</p>
                     <button type="button"

--- a/Angular/viver-cellers/src/app/directives/dni.directive.spec.ts
+++ b/Angular/viver-cellers/src/app/directives/dni.directive.spec.ts
@@ -1,0 +1,8 @@
+import { DniDirective } from './dni.directive';
+
+describe('DniDirective', () => {
+  it('should create an instance', () => {
+    const directive = new DniDirective();
+    expect(directive).toBeTruthy();
+  });
+});

--- a/Angular/viver-cellers/src/app/directives/dni.directive.ts
+++ b/Angular/viver-cellers/src/app/directives/dni.directive.ts
@@ -1,0 +1,39 @@
+// Importamos las necesarias dependencias de Angular
+import { Directive, Input } from '@angular/core';
+import { AbstractControl, NG_VALIDATORS, ValidationErrors, Validator } from '@angular/forms';
+
+@Directive({
+  selector: '[appDni]',
+  providers: [{ provide: NG_VALIDATORS, useExisting: DniDirective, multi: true }]
+})
+export class DniDirective {
+
+  @Input('appDni') dni!: string;
+
+  constructor() { }
+
+  validate(control: AbstractControl): ValidationErrors | null {
+    const dni = control.value;
+    const valid = verificaDNI(dni);
+
+    if (!valid) {
+      return { custom: true };
+    }
+
+    return null;
+  }
+}
+
+function verificaDNI(dni: string): boolean {
+  const lletres = "TRWAGMYFPDXBNJZSQVHLCKE";
+  const num = dni.slice(0, -1);
+  const lle = dni.slice(-1);
+  const residu = parseInt(num) % 23;
+  const lletraBona = lletres[residu];
+
+  return lletraBona === lle.toUpperCase();
+}
+
+
+
+

--- a/Angular/viver-cellers/src/app/directives/repeat-password.directive.spec.ts
+++ b/Angular/viver-cellers/src/app/directives/repeat-password.directive.spec.ts
@@ -1,0 +1,8 @@
+import { RepeatPasswordDirective } from './repeat-password.directive';
+
+describe('RepeatPasswordDirective', () => {
+  it('should create an instance', () => {
+    const directive = new RepeatPasswordDirective();
+    expect(directive).toBeTruthy();
+  });
+});

--- a/Angular/viver-cellers/src/app/directives/repeat-password.directive.ts
+++ b/Angular/viver-cellers/src/app/directives/repeat-password.directive.ts
@@ -1,0 +1,36 @@
+// Importamos las necesarias dependencias de Angular
+import { Directive, Input } from '@angular/core';
+import { AbstractControl, NG_VALIDATORS, ValidationErrors, Validator } from '@angular/forms';
+
+// Definimos una directiva personalizada para validar la repetición de contraseñas
+@Directive({
+  selector: '[appRepeatPassword]',
+  providers: [{ provide: NG_VALIDATORS, useExisting: RepeatPasswordDirective, multi: true }]
+})
+export class RepeatPasswordDirective implements Validator {
+
+  // Capturamos el valor que proviene del formulario
+  @Input('appRepeatPassword') password1!: string;
+
+  constructor() {
+    // Constructor vacío, no realizamos ninguna acción especial al crear la instancia de la directiva
+  }
+
+  // Implementamos un método de validación personalizado
+  validate(control: AbstractControl<any, any>): ValidationErrors | null {
+
+    // Almacenamos el valor del control de la contraseña repetida
+    let repetitPassword = control.value;
+
+    // Obtenemos el control de la contraseña inicial utilizando el nombre proporcionado como input en tiempo real
+    let passwordInicial = control.root.get(this.password1);
+
+    // Verificamos si hay una discrepancia entre las contraseñas y devolvemos un error personalizado si es así
+    if (passwordInicial != null && repetitPassword != passwordInicial.value) {
+      return { custom: true }; // Enviamos un flag que indica un error personalizado
+    }
+
+    // Si las contraseñas coinciden, devolvemos null indicando que la validación ha pasado
+    return null;
+  }
+}


### PR DESCRIPTION
# Create Directives for Register Form

Response to issue #28

## Description:
We need to implement validation for two fields in an Angular registration form: the DNI field and the password repeat field. For this purpose, two custom directives are required: one for validating the DNI format and another for ensuring that passwords match.

## Tasks:

### In `register.component.html`
   - Add the selectors of the custom directives (`appDni` and `appRepeatPassword`) to the corresponding input fields.
   - Include custom error messages for each directive, which are displayed when validation fails.

### In `dni.directive.ts`
   - Create a directive named `DniDirective` that implements the `Validator` interface.
   - Define a `validate` method that checks if the field value complies with the expected format of a Spanish DNI.
   - If the DNI does not comply with the format, return an object of custom errors.

### In `repeat-password.directive.ts`
   - Create a directive named `RepeatPasswordDirective` that implements the `Validator` interface.
   - Define a `validate` method that compares the value of the password repeat field with the value of the initial password field.
   - If the passwords do not match, return an object of custom errors.

<!---
# Create Directives for Register Form

Respuesta a la issue #28 

## Descripción:
Se necesita implementar la validación de dos campos en un formulario de registro en Angular: el campo DNI y el campo de repetición de contraseña. Para ello, se requieren dos directivas personalizadas: una para validar el formato del DNI y otra para asegurarse de que las contraseñas coincidan.

## Tareas:

### En `register.component.html`
   - Se agrega el selector de las directivas personalizadas (`appDni` y `appRepeatPassword`) en los campos de input correspondientes.
   - Se incluyen mensajes de error personalizados para cada directiva, que se muestran cuando la validación falla.

### En `dni.directive.ts`
   - Se crea una directiva llamada `DniDirective` que implementa la interfaz `Validator`.
   - Se define un método `validate` que verifica si el valor del campo cumple con el formato esperado de un DNI español.
   - Si el DNI no cumple con el formato, se devuelve un objeto de errores personalizados.

### En `repeat-password.directive.ts`
   - Se crea una directiva llamada `RepeatPasswordDirective` que implementa la interfaz `Validator`.
   - Se define un método `validate` que compara el valor del campo de repetición de contraseña con el valor del campo de contraseña inicial.
   - Si las contraseñas no coinciden, se devuelve un objeto de errores personalizados.
--->